### PR TITLE
Adjust parent recipe for VSCode jamf-upload recipe

### DIFF
--- a/VisualStudioCode/VisualStudioCode.jamf-upload.recipe.yaml
+++ b/VisualStudioCode/VisualStudioCode.jamf-upload.recipe.yaml
@@ -8,7 +8,7 @@ Description: |
   command-line keys.
 Identifier: com.github.davidbpirie.jamf-upload.VisualStudioCode
 MinimumVersion: '2.3'
-ParentRecipe: com.github.killahquam.pkg.visualstudioscode
+ParentRecipe: com.github.amsysuk-recipes.pkg.VisualStudioCode
 
 Input:
   NAME: VisualStudioCode


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See https://github.com/autopkg/killahquam-recipes/issues/28 for details.)

This pull request adjusts the parent for one recipe that references killahquam-recipes. The parent has been changed to an actively maintained recipe in another repo.