### PR TITLE
Adjust AirPort Utility download

### DIFF
--- a/AirPortUtility/AirPortUtility.download.recipe.yaml
+++ b/AirPortUtility/AirPortUtility.download.recipe.yaml
@@ -7,13 +7,9 @@ Input:
   LOCALE: en_AU
 
 Process:
-- Processor: com.github.n8felton.shared/AppleSupportDownloadInfoProvider
-  Arguments:
-    ARTICLE_NUMBER: '1664'
-
 - Processor: URLDownloader
   Arguments:
-    url: '%url%'
+    url: 'https://updates.cdn-apple.com/2019/cert/041-90809-20191028-de07bcac-151f-4c5f-9626-1ba7d0db1a49/AirPortUtility.dmg'
 
 - Processor: EndOfCheckPhase
 


### PR DESCRIPTION
This PR updates the method used to download Apple's AirPort Utility, as the previous provider processor wasn't working.

Verbose recipe run output:

```
% autopkg run -vvq 'AirPortUtility/AirPortUtility.download.recipe.yaml'
Processing AirPortUtility/AirPortUtility.download.recipe.yaml...
WARNING: AirPortUtility/AirPortUtility.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://updates.cdn-apple.com/2019/cert/041-90809-20191028-de07bcac-151f-4c5f-9626-1ba7d0db1a49/AirPortUtility.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 29 Oct 2019 00:09:27 GMT
URLDownloader: Storing new ETag header: "eddfad97b879f964a84af9646c85b3b9"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/downloads/AirPortUtility.dmg
{'Output': {'download_changed': True,
            'etag': '"eddfad97b879f964a84af9646c85b3b9"',
            'last_modified': 'Tue, 29 Oct 2019 00:09:27 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/downloads/AirPortUtility.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/downloads/AirPortUtility.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Software Update',
                                        'Apple Software Update Certification '
                                        'Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/downloads/AirPortUtility.dmg/AirPortUtility.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/downloads/AirPortUtility.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AirPortUtility.pkg":
CodeSignatureVerifier:    Status: signed Apple Software
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2019-07-18 20:17:12 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Software Update
CodeSignatureVerifier:        Expires: 2029-04-14 21:28:23 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66
CodeSignatureVerifier:            80 28 92 05 83 B1 E8 96 EB B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Apple Software Update Certification Authority
CodeSignatureVerifier:        Expires: 2031-10-15 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D
CodeSignatureVerifier:            D1 85 0B 82 74 F3 5C 71 74 5C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/receipts/AirPortUtility.download.recipe-receipt-20241225-132143.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.davidbpirie.download.AirPortUtility/downloads/AirPortUtility.dmg
```

