### PR TITLE
Update DYMOConnect.download.recipe.yaml

### DIFF
--- a/DYMO/DYMOConnect.download.recipe.yaml
+++ b/DYMO/DYMOConnect.download.recipe.yaml
@@ -7,6 +7,14 @@ Input:
   BASE_URL: https://www.dymo.com/support?cfid=user-guide
   RE_PATTERN: href=\"([^\"]*DCDMac[0-9\.]*\.pkg)\">\s*Download
   USER_AGENT: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.82
+  ACCEPT: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8
+  ACCEPT_LANGUAGE: en-US,en;q=0.9
+  CONNECTION: keep-alive
+  UPGRADE-INSECURE-REQUESTS: 1
+  SEC_FETCH_SITE: none
+  SEC_FETCH_MODE: navigate
+  SEC_FETCH_USER: ?1
+  SEC-FETCH-DEST: document
 
 Process:
 - Processor: URLTextSearcher
@@ -14,6 +22,14 @@ Process:
     re_pattern: '%RE_PATTERN%'
     request_headers:
       user-agent: '%USER_AGENT%'
+      accept: '%ACCEPT'
+      accept-language: '%ACCEPT_LANGUAGE'
+      connection: '%CONNECTION'
+      upgrade-insecure-requests: '%UPGRADE-INSECURE-REQUESTS'
+      sec-fetch-site: '%SEC_FETCH_SITE'
+      sec-fetch-mode: '%SEC_FETCH_MODE'
+      sec-fetch-user: '%SEC_FETCH_USER'
+      sec-fetch-dest: '%SEC_FETCH_DEST'
     result_output_var_name: url
     url: '%BASE_URL%'
 


### PR DESCRIPTION
I noticed when curling the DYMO Connect's download page (https://www.dymo.com/support?cfid=user-guide) with only user-agent headers (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.82), it seemed to be that my success rate of the curling was about 5-10 %. It almost never went trough.

Adding more headers to make the curl request seem more "human-like", it seems the success rate is close to 100 %. At least it has not failed for me yet.

I if would be possible to add more headers for the get reguest (as in this PR), so it would be successful more often?