### PR TITLE
Change parent to Santa.download in zentral-recipes

### DIFF
--- a/North Pole Security/NorthPoleSecSanta.download.recipe.yaml
+++ b/North Pole Security/NorthPoleSecSanta.download.recipe.yaml
@@ -13,6 +13,10 @@ Input:
   GITHUB_ASSET_REGEX: '.*\.%DOWNLOAD_SUFFIX%'
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: Consider switching to the Santa recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.
+
   - Processor: GitHubReleasesInfoProvider
     Arguments:
       github_repo: '%GITHUB_REPO%'

--- a/North Pole Security/NorthPoleSecSanta.pkg.recipe.yaml
+++ b/North Pole Security/NorthPoleSecSanta.pkg.recipe.yaml
@@ -4,7 +4,7 @@ Description: |
   version.
 
 Identifier: com.github.davidbpirie.pkg.NorthPoleSecSanta
-ParentRecipe: com.github.davidbpirie.download.NorthPoleSecSanta
+ParentRecipe: com.github.autopkg.zentral.download.santa
 MinimumVersion: 2.3.0
 
 Input:


### PR DESCRIPTION
The Santa download recipe in this repo is similar in function the earlier-created ones in zentral-recipes. This PR changes the parent recipes to that one for the Santa recipes in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!