### PR TITLE
Switch parent of Calibrite Profiler recipes to TekTekkers-recipes

### DIFF
--- a/calibrite/calibritePROFILER.download.recipe.yaml
+++ b/calibrite/calibritePROFILER.download.recipe.yaml
@@ -8,6 +8,10 @@ Input:
   NAME: calibritePROFILER
 
 Process:
+- Processor: DeprecationWarning
+  Arguments:
+    warning_message: Consider switching to the calibritePROFILER recipes in the TekTekkers-recipes repo. This recipe is deprecated and will be removed in the future.
+
 - Processor: GitHubReleasesInfoProvider
   Arguments:
     github_repo: LUMESCA/calibrite-profiler-releases

--- a/calibrite/calibritePROFILER.pkg.recipe.yaml
+++ b/calibrite/calibritePROFILER.pkg.recipe.yaml
@@ -2,7 +2,7 @@ Description: |
   Downloads the latest release of calibrite PROFILER as a dmg,
   verifies the signature and extracts the version, then generates a pkg.
 Identifier: com.github.davidbpirie.pkg.calibritePROFILER
-ParentRecipe: com.github.davidbpirie.download.calibritePROFILER
+ParentRecipe: com.github.TekTekkers.download.calibritePROFILER
 MinimumVersion: 2.3.0
 
 Input:


### PR DESCRIPTION
The Calibrite Profiler download recipe in this repo is similar in function the earlier-created ones in TekTekkers-recipes. This PR changes the parent recipes to that one for the Calibrite Profiler recipes in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!