### PR TITLE
Pre commit config update and minor fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.21.0
+    rev: v1.21.1
     hooks:
       - id: check-autopkg-recipes
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.10.1
+    rev: v1.21.0
     hooks:
       - id: check-autopkg-recipes
         args:
@@ -13,28 +13,27 @@ repos:
       - id: forbid-autopkg-overrides
       - id: forbid-autopkg-trust-info
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 25.9.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=100"]
       - id: check-ast
-      - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-yaml
       - id: detect-private-key
-      - id: fix-encoding-pragma
+      - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: no-commit-to-branch
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext=md"]
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 7.3.0
     hooks:
       - id: flake8

--- a/Allen and Heath/AllenHeathDTPreampControl.pkg.recipe.yaml
+++ b/Allen and Heath/AllenHeathDTPreampControl.pkg.recipe.yaml
@@ -42,7 +42,7 @@ Process:
     Arguments:
       flat_pkg_path: '%RECIPE_CACHE_DIR%/%NAME%.dmg/*.pkg'
       destination_path: '%RECIPE_CACHE_DIR%/unpack'
-  
+
   - Processor: com.github.nmcspadden.shared/PackageInfoVersioner
     Arguments:
       package_info_path: '%RECIPE_CACHE_DIR%/unpack/DTPreampControl.pkg/PackageInfo'

--- a/Avid/AvidProToolsPluginDMG.jamf-upload.recipe.yaml
+++ b/Avid/AvidProToolsPluginDMG.jamf-upload.recipe.yaml
@@ -7,7 +7,7 @@ Description: |
 
   For use where Avid has *helpfully* included content
   on the dmg outside of the pkg (e.g. AIR Instruments Bundle, Xpand2).
-  
+
   All Pro Tools plug-ins include a <plugin> AppMan.pkg component,
   so version information is read from there.
 

--- a/Avid/AvidProToolsPluginDMG.pkg.recipe.yaml
+++ b/Avid/AvidProToolsPluginDMG.pkg.recipe.yaml
@@ -6,7 +6,7 @@ Description: |
 
   For use where Avid has *helpfully* included content
   on the dmg outside of the pkg (e.g. AIR Instruments Bundle, Xpand2).
-  
+
   All Pro Tools plug-ins include a <plugin> AppMan.pkg component,
   so version information is read from there.
 

--- a/AzulZuluJava/AzulZuluJavaInfoProvider.py
+++ b/AzulZuluJava/AzulZuluJavaInfoProvider.py
@@ -19,7 +19,7 @@ from autopkglib import ProcessorError
 from autopkglib.URLGetter import URLGetter
 
 import urllib.request
-import json 
+import json
 
 __all__ = ["AzulZuluJavaInfoProvider"]
 
@@ -33,10 +33,8 @@ SUPPORTED_ARCHS = ["x86", "arm"]
 SUPPORTED_EXTENSIONS = ["zip", "tar.gz", "dmg"]
 SUPPORTED_BUNDLE_TYPES = ["jre", "jdk", "jre_fx", "jdk_fx"]
 
-MUNKI_ARCHS = {
-    "x86": "x86_64",
-    "arm": "arm64"
-}
+MUNKI_ARCHS = {"x86": "x86_64", "arm": "arm64"}
+
 
 class AzulZuluJavaInfoProvider(URLGetter):
     """Provides URL to the latest Azul Zulu Java release."""
@@ -70,43 +68,53 @@ class AzulZuluJavaInfoProvider(URLGetter):
         "java_version": {"description": "Java version."},
         "openjdk_build_number": {"description": "OpenJDK build number."},
         "sha256_hash": {"description": "SHA256 hash for the download."},
-        "munki_arch": {"description": "Architecture appropriate for the munki pkginfo key supported_architectures"},
+        "munki_arch": {
+            "description": "Architecture appropriate for the munki pkginfo key supported_architectures"
+        },
     }
-
 
     def main(self):
         api_url = self.env.get("api_url", DEFAULT_API_URL)
-        java_major_version = self.env.get("java_major_version", DEFAULT_JAVA_MAJOR_VERSION)
+        java_major_version = self.env.get(
+            "java_major_version", DEFAULT_JAVA_MAJOR_VERSION
+        )
         arch = self.env.get("arch", DEFAULT_ARCH)
         if arch not in SUPPORTED_ARCHS:
-            raise ProcessorError(f"arch {arch} not one of those supported: {', '.join(SUPPORTED_ARCHS)}.")
+            raise ProcessorError(
+                f"arch {arch} not one of those supported: {', '.join(SUPPORTED_ARCHS)}."
+            )
         extension = self.env.get("extension", DEFAULT_EXTENSION)
         if extension not in SUPPORTED_EXTENSIONS:
-            raise ProcessorError(f"extension {extension} not one of those supported: {', '.join(SUPPORTED_EXTENSIONS)}.")
+            raise ProcessorError(
+                f"extension {extension} not one of those supported: {', '.join(SUPPORTED_EXTENSIONS)}."
+            )
         javafx = False
         bundle_type = self.env.get("bundle_type", DEFAULT_BUNDLE_TYPE)
         if bundle_type not in SUPPORTED_BUNDLE_TYPES:
-            raise ProcessorError(f"bundle_type {bundle_type} not one of those supported: {', '.join(SUPPORTED_BUNDLE_TYPES)}.")
+            raise ProcessorError(
+                f"bundle_type {bundle_type} not one of those supported: {', '.join(SUPPORTED_BUNDLE_TYPES)}."
+            )
         if bundle_type.endswith("_fx"):
             bundle_type = bundle_type[:-3]
             javafx = True
 
-
         source_files = json.loads(self.download(api_url, text=True))
         for source_file in source_files:
             if (
-                source_file["latest"] and
-                source_file["os"] == "macos" and
-                str(source_file["java_version"][0]) == java_major_version and
-                source_file["arch"] == arch and
-                source_file["ext"] == extension and
-                source_file["bundle_type"] == bundle_type and
-                source_file["javafx"] == javafx
+                source_file["latest"]
+                and source_file["os"] == "macos"
+                and str(source_file["java_version"][0]) == java_major_version
+                and source_file["arch"] == arch
+                and source_file["ext"] == extension
+                and source_file["bundle_type"] == bundle_type
+                and source_file["javafx"] == javafx
             ):
                 data = source_file
                 break
         else:
-            raise ProcessorError(f"No source file found matching the requested criteria of java_major_version={java_major_version}, arch={arch}, extension={extension}, bundle_type={bundle_type}, javafx={javafx}")
+            raise ProcessorError(
+                f"No source file found matching the requested criteria of java_major_version={java_major_version}, arch={arch}, extension={extension}, bundle_type={bundle_type}, javafx={javafx}"
+            )
         self.env["url"] = data["url"]
         self.env["version"] = ".".join([str(x) for x in data["zulu_version"]])
         self.env["java_version"] = ".".join([str(x) for x in data["java_version"]])

--- a/AzureDataStudio/AzureDataStudio.jamf-upload.recipe.yaml
+++ b/AzureDataStudio/AzureDataStudio.jamf-upload.recipe.yaml
@@ -15,7 +15,7 @@ Input:
   NAME: AzureDataStudio
   JAMF_CATEGORY: Developer Tools
   JAMF_PKG_NAME: '%NAME%'
-  JAMF_PKG_INFO: 
+  JAMF_PKG_INFO:
     Azure Data Studio is a cross-platform database tool for data professionals
     using on-premises and cloud data platforms on Windows, macOS, and Linux.
   JAMF_PKG_NOTES: 'Generated and uploaded by AutoPkg'

--- a/CiscoSecureClient/CiscoSecureClient.pkg.recipe.yaml
+++ b/CiscoSecureClient/CiscoSecureClient.pkg.recipe.yaml
@@ -12,7 +12,7 @@ Description: |
   CSC_LAUNCHATLOGIN_DISABLE if non-empty will disable Cisco Secure Client
   from automatically launching at login by running:
     acinstallhelper -launchAtLogin -disable
-  
+
   CSC_DISABLEAUTOSTART if non-empty will disable Cisco Secure Client from
   automatically launching at login by running:
     /Applications/Cisco/Cisco\ Secure\ Client.app/Contents/MacOS/Cisco\ Secure\ Client disableAutoStart

--- a/Devolutions/DevolutionsRemoteDesktopManager.jamf-upload.recipe.yaml
+++ b/Devolutions/DevolutionsRemoteDesktopManager.jamf-upload.recipe.yaml
@@ -16,14 +16,14 @@ Input:
   NAME: DevolutionsRemoteDesktopManager
   JAMF_CATEGORY: Business
   JAMF_PKG_NAME: '%NAME%'
-  JAMF_PKG_INFO: Remote Desktop Manager (RDM) centralizes all remote connections 
-    on a single platform that is securely shared between users and across the 
-    entire team. With support for hundreds of integrated technologies — including 
-    multiple protocols and VPNs — along with built-in enterprise-grade password 
-    management tools, global and granular-level access controls, and robust mobile 
-    apps to complement desktop clients for Windows and Mac, RDM is a IT toolbox for 
-    remote access. RDM empowers IT departments to drive security, speed and 
-    productivity throughout the organization, while reducing inefficiency, cost and 
+  JAMF_PKG_INFO: Remote Desktop Manager (RDM) centralizes all remote connections
+    on a single platform that is securely shared between users and across the
+    entire team. With support for hundreds of integrated technologies — including
+    multiple protocols and VPNs — along with built-in enterprise-grade password
+    management tools, global and granular-level access controls, and robust mobile
+    apps to complement desktop clients for Windows and Mac, RDM is a IT toolbox for
+    remote access. RDM empowers IT departments to drive security, speed and
+    productivity throughout the organization, while reducing inefficiency, cost and
     risk.
   JAMF_PKG_NOTES: Uploaded by AutoPkg
   JAMF_PKG_OS_REQUIREMENTS: ''

--- a/Digital Audio Denmark/DigitalAudioDenmark.cookie.recipe.yaml
+++ b/Digital Audio Denmark/DigitalAudioDenmark.cookie.recipe.yaml
@@ -43,3 +43,5 @@ Process:
         - '%RECIPE_CACHE_DIR%/cookie_jar.txt'
         - --data
         - username-%FORM_ID%=%WEB_USERNAME%&user_password-%FORM_ID%=%WEB_PASSWORD%&form_id=%FORM_ID%&_wpnonce=%wp_nonce%
+
+  - Processor: EndOfCheckPhase

--- a/Generic/GenericDockItem.munki.recipe.yaml
+++ b/Generic/GenericDockItem.munki.recipe.yaml
@@ -52,14 +52,14 @@ Process:
   Arguments:
     file_content: |
       #!/bin/sh
-          
+
       INSTALLATION_PACKAGE="$1"
       INSTALLATION_DESTINATION="$2"
       INSTALLATION_VOLUME="$3"
       INSTALLATION_SYSTEM_ROOT="$4"
-      
+
       USERTEMPLATEDOCK="${INSTALLATION_VOLUME}%USER_TEMPLATE_PATH%/Library/Preferences/com.apple.dock.plist"
-      
+
       /usr/bin/touch "${USERTEMPLATEDOCK}"
       /usr/local/bin/dockutil --add "%DOCKUTIL_ITEM%" --label "%DOCKUTIL_LABEL%" %DOCKUTIL_FOLDEROPTIONS% --replacing "%DOCKUTIL_REPLACING%" %DOCKUTIL_POSITIONOPTONS% --no-restart "${USERTEMPLATEDOCK}" || /usr/bin/true
       /usr/local/bin/dockutil --add "%DOCKUTIL_ITEM%" --label "%DOCKUTIL_LABEL%" %DOCKUTIL_FOLDEROPTIONS% --replacing "%DOCKUTIL_REPLACING%" %DOCKUTIL_POSITIONOPTONS% --allhomes || /usr/bin/true
@@ -70,9 +70,9 @@ Process:
   Arguments:
     file_content: |
       #!/bin/sh
-      
+
       USERTEMPLATEDOCK="%USER_TEMPLATE_PATH%/Library/Preferences/com.apple.dock.plist"
-      
+
       /usr/local/bin/dockutil --remove "%DOCKUTIL_LABEL%" --no-restart "${USERTEMPLATEDOCK}"
       /usr/local/bin/dockutil --remove "%DOCKUTIL_LABEL%" --allhomes
       /usr/sbin/pkgutil --forget "%PKG_ID%"

--- a/Generic/GenericOutsetItemWithOverride.pkg.recipe.yaml
+++ b/Generic/GenericOutsetItemWithOverride.pkg.recipe.yaml
@@ -10,7 +10,7 @@ Description: |
   installed in i.e. one of:
     login-once
     login-privileged-once
-  
+
   Uses StringReplacer processor from com.github.grahampugh.recipes.commonprocessors.
 
   When using the recipe, also provide the source_path and version via the -k parameter eg:
@@ -68,12 +68,12 @@ Process:
   Arguments:
     file_content: |
       #!/bin/sh
-          
+
       INSTALLATION_PACKAGE="$1"
       INSTALLATION_DESTINATION="$2"
       INSTALLATION_VOLUME="$3"
       INSTALLATION_SYSTEM_ROOT="$4"
-      
+
       if [ "${INSTALLATION_VOLUME}" != "/" ]; then
         exit 0
       fi

--- a/Generic/GenericSoftwareRestriction.jamf.recipe.yaml
+++ b/Generic/GenericSoftwareRestriction.jamf.recipe.yaml
@@ -17,7 +17,7 @@ Description: |
   only performs substitutions on a specific set of key names, so the
   provided template GenericSoftwareRestrictionTemplate.xml should be
   used as a base - in most cases with no modification.
-  
+
   It is recommended to store your customised template in your
   RecipeOverrides directory and can be shared across multiple recipe
   overrides.

--- a/Logitech/LogitechOptionsPlus.download.recipe.yaml
+++ b/Logitech/LogitechOptionsPlus.download.recipe.yaml
@@ -20,6 +20,8 @@ Process:
     filename: '%NAME%.zip'
     url: '%DOWNLOAD_URL%'
 
+- Processor: EndOfCheckPhase
+
 - Processor: Unarchiver
   Arguments:
     destination_path: '%RECIPE_CACHE_DIR%/expand'

--- a/MicrosoftRemoteDesktop/MicrosoftRemoteDesktop.jamf-upload.recipe.yaml
+++ b/MicrosoftRemoteDesktop/MicrosoftRemoteDesktop.jamf-upload.recipe.yaml
@@ -29,12 +29,12 @@ Process:
     Arguments:
       flat_pkg_path: '%pathname%'
       destination_path: '%RECIPE_CACHE_DIR%/unpack'
-  
+
   - Processor: PkgPayloadUnpacker
     Arguments:
       pkg_payload_path: '%RECIPE_CACHE_DIR%/unpack/com.microsoft.rdc.macos.pkg/Payload'
       destination_path: '%RECIPE_CACHE_DIR%/payload'
-  
+
   - Processor: PlistReader
     Arguments:
       info_path: '%RECIPE_CACHE_DIR%/payload/Microsoft Remote Desktop.app'

--- a/PACE Anti-Piracy/iLokLicenseManager.pkg.recipe.yaml
+++ b/PACE Anti-Piracy/iLokLicenseManager.pkg.recipe.yaml
@@ -1,5 +1,5 @@
 Description: |
-  Downloads the latest iLok License Manager disk image, then copies 
+  Downloads the latest iLok License Manager disk image, then copies
   the package from the DMG, extracting the version.
 
 Identifier: com.github.davidbpirie.pkg.iLokLicenseManager

--- a/SharedProcessors/CodeSigner.py
+++ b/SharedProcessors/CodeSigner.py
@@ -27,11 +27,11 @@ __all__ = ["CodeSigner"]
 
 
 class CodeSigner(Processor):
-    description = ( "Run codesign on a target." )
+    description = "Run codesign on a target."
     input_variables = {
         "target_path": {
             "required": True,
-            "description": "Path to the target to be signed."
+            "description": "Path to the target to be signed.",
         },
     }
     output_variables = {}
@@ -50,13 +50,13 @@ class CodeSigner(Processor):
             "--sign",
             "-",
             "--timestamp=none",
-            target_path
+            target_path,
         ]
 
         self.output(f'Running command: {" ".join(command_line_list)}')
         subprocess.call(command_line_list)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     processor = CodeSigner()
     processor.execute_shell()

--- a/SharedProcessors/FileTemplateFromLists.py
+++ b/SharedProcessors/FileTemplateFromLists.py
@@ -20,6 +20,7 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["FileTemplateFromLists"]
 
+
 class MyTemplate(Template):
     pattern = r"""
     %(?:
@@ -29,6 +30,7 @@ class MyTemplate(Template):
       (?P<invalid>)                        # Other ill-formed delimiter exprs
     )%
     """
+
 
 class FileTemplateFromLists(Processor):
     """This processor uses Python's string.Template() class to substitute
@@ -75,14 +77,12 @@ class FileTemplateFromLists(Processor):
         },
         "substitution_dict": {
             "required": False,
-            "description": "Dictionary of inputs, with the key as the placeholder to be substituted. See Processor Description for more details."
+            "description": "Dictionary of inputs, with the key as the placeholder to be substituted. See Processor Description for more details.",
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     description = __doc__
-
 
     def main(self):
         template_path = self.env["template_path"]
@@ -93,14 +93,18 @@ class FileTemplateFromLists(Processor):
         if not substitution_dict:
             substitution_dict = {}
         if type(substitution_dict) != dict:
-            raise ProcessorError(f"substitution_dict must be a dictionary - {type(substitution_dict)} provided.")
+            raise ProcessorError(
+                f"substitution_dict must be a dictionary - {type(substitution_dict)} provided."
+            )
 
         # Generate substitutions
         substitutions = {}
         for substitution_name, substitution_input in substitution_dict.items():
             # Validate key value
             if type(substitution_input) != dict:
-                raise ProcessorError(f"substitution_dict values must all be dictionaries - {type(substitution_input)} provided for key {substitution_name}.")
+                raise ProcessorError(
+                    f"substitution_dict values must all be dictionaries - {type(substitution_input)} provided for key {substitution_name}."
+                )
 
             input_strings = substitution_input.get("input_strings")
             prefix = substitution_input.get("prefix")
@@ -117,23 +121,29 @@ class FileTemplateFromLists(Processor):
 
                 # Concatenate each value, with value prefix/suffix
                 for input_string in input_strings:
-                    substitutions[substitution_name] += f"{str(value_prefix or '')}{input_string}{str(value_suffix or '')}"
+                    substitutions[
+                        substitution_name
+                    ] += f"{str(value_prefix or '')}{input_string}{str(value_suffix or '')}"
 
                 # Add prefix/suffix if not empty
                 if substitutions[substitution_name]:
-                    substitutions[substitution_name] = f"{str(prefix or '')}{substitutions[substitution_name]}{str(suffix or '')}"
+                    substitutions[substitution_name] = (
+                        f"{str(prefix or '')}{substitutions[substitution_name]}{str(suffix or '')}"
+                    )
 
-            self.output(f"Substituting {substitution_name} with '{substitutions[substitution_name]}' if found.")
+            self.output(
+                f"Substituting {substitution_name} with '{substitutions[substitution_name]}' if found."
+            )
 
         # Read source template
-        with open(template_path, 'r') as template_file:
+        with open(template_path, "r") as template_file:
             template_string = template_file.read()
 
         # Perform substitution
         substituted_string = MyTemplate(template_string).safe_substitute(substitutions)
 
         # Write the substituted text to the destination file
-        with open(destination_path, 'w') as destination_file:
+        with open(destination_path, "w") as destination_file:
             destination_file.write(substituted_string)
 
         self.output(f"Templated {template_path} to {destination_path}.")

--- a/SharedProcessors/FirstActivePackageInChoice.py
+++ b/SharedProcessors/FirstActivePackageInChoice.py
@@ -44,7 +44,9 @@ class FirstActivePackageInChoice(Processor):
         },
     }
     output_variables = {
-        "first_active_pkg": {"description": "The name of the first pkg in pathsOfActivePackagesInChoice."}
+        "first_active_pkg": {
+            "description": "The name of the first pkg in pathsOfActivePackagesInChoice."
+        }
     }
 
     def output_showchoicesxml(self, choices_pkg_path: str):
@@ -75,7 +77,9 @@ class FirstActivePackageInChoice(Processor):
     def get_child_with_identifier(self, child_items: list, desired_choice: str):
         for child_item in child_items:
             if child_item["childItems"]:
-                result = self.get_child_with_identifier(child_items=child_item["childItems"], desired_choice=desired_choice)
+                result = self.get_child_with_identifier(
+                    child_items=child_item["childItems"], desired_choice=desired_choice
+                )
                 if result:
                     return result
             if child_item["choiceIdentifier"] == desired_choice:
@@ -87,10 +91,15 @@ class FirstActivePackageInChoice(Processor):
         desired_choice = self.env.get("desired_choice")
 
         child_items = self.output_showchoicesxml(choices_pkg_path)
-        desired_child_item = self.get_child_with_identifier(child_items=child_items, desired_choice=desired_choice)
-        first_active_pkg = urllib.parse.unquote(desired_child_item["pathsOfActivePackagesInChoice"][0].split("#",1)[1])
+        desired_child_item = self.get_child_with_identifier(
+            child_items=child_items, desired_choice=desired_choice
+        )
+        first_active_pkg = urllib.parse.unquote(
+            desired_child_item["pathsOfActivePackagesInChoice"][0].split("#", 1)[1]
+        )
         self.env["first_active_pkg"] = first_active_pkg
         self.output(f"first_active_pkg: {self.env['first_active_pkg']}")
+
 
 if __name__ == "__main__":
     PROCESSOR = FirstActivePackageInChoice()

--- a/SharedProcessors/FlatToDistPkg.py
+++ b/SharedProcessors/FlatToDistPkg.py
@@ -26,43 +26,44 @@ __all__ = ["FlatToDistPkg"]
 
 
 class FlatToDistPkg(Processor):
-    description = ( "Converts a flat package to a distribution-style package." )
+    description = "Converts a flat package to a distribution-style package."
     input_variables = {
         "pkg_path": {
             "required": True,
-            "description": "Path to the flat package to be converted."
+            "description": "Path to the flat package to be converted.",
         }
     }
     output_variables = {
-        "pkg_path": {
-             "description": "Path to the distribution-style pacakge."
-        }
-   }
+        "pkg_path": {"description": "Path to the distribution-style pacakge."}
+    }
 
     __doc__ = description
 
     def main(self):
 
-    	# rename flat package so that we can slot the distribution-style package into place
-        pkg_dir = os.path.dirname( self.env[ "pkg_path" ] )
-        pkg_base_name = os.path.basename( self.env[ "pkg_path" ] )
-        ( pkg_name_no_extension, pkg_extension ) = os.path.splitext( pkg_base_name )
+        # rename flat package so that we can slot the distribution-style package into place
+        pkg_dir = os.path.dirname(self.env["pkg_path"])
+        pkg_base_name = os.path.basename(self.env["pkg_path"])
+        (pkg_name_no_extension, pkg_extension) = os.path.splitext(pkg_base_name)
 
-        flat_pkg_path = os.path.join( pkg_dir, pkg_name_no_extension + "-flat" + pkg_extension )
-        os.rename( self.env[ "pkg_path" ], flat_pkg_path )
+        flat_pkg_path = os.path.join(
+            pkg_dir, pkg_name_no_extension + "-flat" + pkg_extension
+        )
+        os.rename(self.env["pkg_path"], flat_pkg_path)
 
-        command_line_list = [ "/usr/bin/productbuild", \
-                              "--package", \
-                              flat_pkg_path, \
-                              self.env[ "pkg_path" ] ]
+        command_line_list = [
+            "/usr/bin/productbuild",
+            "--package",
+            flat_pkg_path,
+            self.env["pkg_path"],
+        ]
 
         print(command_line_list)
 
         # print command_line_list
-        subprocess.call( command_line_list )
+        subprocess.call(command_line_list)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     processor = FlatToDistPkg()
     processor.execute_shell()

--- a/SharedProcessors/GitRepoClone.py
+++ b/SharedProcessors/GitRepoClone.py
@@ -26,47 +26,49 @@ __all__ = ["GitRepoClone"]
 
 
 class GitRepoClone(Processor):
-    description = ("Clones a git repo with git.")
+    description = "Clones a git repo with git."
     input_variables = {
         "repo_url": {
             "required": True,
-            "description": "URL of the git repo to be cloned."
+            "description": "URL of the git repo to be cloned.",
         },
         "repo_directory": {
             "required": True,
-            "description": "Path to the directory the repo is cloned to."
+            "description": "Path to the directory the repo is cloned to.",
         },
         "replace_existing": {
             "required": False,
             "description": "Boolean. When set to True (or anything that equates to True), if the repo_path already exists, delete it before cloning. Defaults to False.",
-            "default": "False"
+            "default": "False",
         },
         "allow_existing": {
             "required": False,
             "description": "Boolean. When set to False (or anything that equates to False) and replace_existing is True, if the repo_path already exists exits with an error. Defaults to False.",
-            "default": "False"
-        }
+            "default": "False",
+        },
     }
     output_variables = {
         "repo_cloned": {
-             "description": "String. 'True' if a git clone is performed, 'False' if not."
+            "description": "String. 'True' if a git clone is performed, 'False' if not."
         }
-   }
+    }
 
     __doc__ = description
 
     def main(self):
         self.repo_url: str = self.env.get("repo_url")
         self.repo_directory: Path = Path(self.env.get("repo_directory"))
-        self.replace_existing: bool = (self.env.get("replace_existing", False) == True)
-        self.allow_existing: bool = (self.env.get("allow_existing", False) == True)
+        self.replace_existing: bool = self.env.get("replace_existing", False) == True
+        self.allow_existing: bool = self.env.get("allow_existing", False) == True
         self.repo_cloned: bool = False
 
         if not self.repo_url:
             raise ProcessorError(f"repo_url cannot be empty")
 
         if not self.repo_directory.parent.exists():
-            self.output(f"Destination parent directory {self.repo_directory.parent} does not exist - creating.")
+            self.output(
+                f"Destination parent directory {self.repo_directory.parent} does not exist - creating."
+            )
             self.repo_directory.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
 
         if self.repo_directory.exists() and self.replace_existing:
@@ -76,30 +78,46 @@ class GitRepoClone(Processor):
                 elif self.repo_directory.is_dir():
                     shutil.rmtree(self.repo_directory)
                 else:
-                    raise ProcessorError(f"Could not remove {self.repo_directory} - it is not a file, link, or directory.")
+                    raise ProcessorError(
+                        f"Could not remove {self.repo_directory} - it is not a file, link, or directory."
+                    )
                 self.output(f"Deleted {self.repo_directory}.")
             except OSError as err:
                 raise ProcessorError(f"Could not remove {self.repo_directory}: {err}")
 
         if self.repo_directory.exists():
             if self.allow_existing:
-                self.output(f"Repo directory {self.repo_directory} exists and allow_existing is {self.allow_existing}.")
+                self.output(
+                    f"Repo directory {self.repo_directory} exists and allow_existing is {self.allow_existing}."
+                )
             else:
-                raise ProcessorError(f"{self.repo_directory} exists but allow_existing is {self.allow_existing}.")
+                raise ProcessorError(
+                    f"{self.repo_directory} exists but allow_existing is {self.allow_existing}."
+                )
         else:
             try:
-                args=f"git clone '{str(self.repo_url)}' '{str(self.repo_directory)}'"
+                args = f"git clone '{str(self.repo_url)}' '{str(self.repo_directory)}'"
                 self.output(f"Running command: {args}")
-                self.output(subprocess.run(args=args, shell=True, cwd=self.env.get("RECIPE_CACHE_DIR"), capture_output=True, check=True, text=True).stdout)
+                self.output(
+                    subprocess.run(
+                        args=args,
+                        shell=True,
+                        cwd=self.env.get("RECIPE_CACHE_DIR"),
+                        capture_output=True,
+                        check=True,
+                        text=True,
+                    ).stdout
+                )
             except subprocess.CalledProcessError as e:
-                raise ProcessorError(f"Error running subprocess: {str(e)}; {e.stderr}; {e.stdout}.")
+                raise ProcessorError(
+                    f"Error running subprocess: {str(e)}; {e.stderr}; {e.stdout}."
+                )
             self.repo_cloned = True
 
         self.env["repo_cloned"] = str(self.repo_cloned)
         self.output(f"repo_cloned: {self.env['repo_cloned']}")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     processor = GitRepoClone()
     processor.execute_shell()

--- a/SharedProcessors/OSACompiler.py
+++ b/SharedProcessors/OSACompiler.py
@@ -27,16 +27,18 @@ __all__ = ["OSACompiler"]
 
 
 class OSACompiler(Processor):
-    description = ( "Compile AppleScripts and other OSA language scripts using osacompile." )
+    description = (
+        "Compile AppleScripts and other OSA language scripts using osacompile."
+    )
     input_variables = {
         "script_source": {
             "required": True,
-            "description": "Path to the source file to be compiled."
+            "description": "Path to the source file to be compiled.",
         },
         "compiled_script": {
             "required": True,
-            "description": "Path to the compiled result. Will be deleted first if already exists."
-        }
+            "description": "Path to the compiled result. Will be deleted first if already exists.",
+        },
     }
     output_variables = {}
 
@@ -48,24 +50,28 @@ class OSACompiler(Processor):
 
         if os.path.exists(compiled_script):
             try:
-                if os.path.isdir(compiled_script) and not os.path.islink(compiled_script):
+                if os.path.isdir(compiled_script) and not os.path.islink(
+                    compiled_script
+                ):
                     shutil.rmtree(compiled_script)
                 else:
                     os.unlink(compiled_script)
             except OSError as err:
-                raise ProcessorError(f"Can't remove existing {compiled_script}: {err.strerror}")
+                raise ProcessorError(
+                    f"Can't remove existing {compiled_script}: {err.strerror}"
+                )
 
         command_line_list = [
             "/usr/bin/osacompile",
             "-o",
             compiled_script,
-            script_source
+            script_source,
         ]
 
         self.output(f'Running command: {" ".join(command_line_list)}')
         subprocess.call(command_line_list)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     processor = OSACompiler()
     processor.execute_shell()

--- a/SharedProcessors/RunShellCommand.py
+++ b/SharedProcessors/RunShellCommand.py
@@ -41,16 +41,12 @@ class RunShellCommand(Processor):
         },
         "subprocess_cwd": {
             "description": "Current working directory to run the command from. Defaults to %RECIPE_CACHE_DIR%.",
-            "required": False
-        }
+            "required": False,
+        },
     }
     output_variables = {
-        "subprocess_args": {
-            "description": "Array of the arguments that were run."
-        },
-        "subprocess_returncode": {
-            "description": "The return code of the subprocess."
-        },
+        "subprocess_args": {"description": "Array of the arguments that were run."},
+        "subprocess_returncode": {"description": "The return code of the subprocess."},
         "subprocess_stdout": {
             "description": "The standard output of the subprocess.",
         },
@@ -62,19 +58,32 @@ class RunShellCommand(Processor):
     def main(self):
         self.subprocess_args = self.env.get("subprocess_args")
         self.subprocess_timeout = self.env.get("subprocess_timeout", None)
-        self.subprocess_fail_on_error = (str(self.env.get("subprocess_fail_on_error")).lower() == "true")
-        self.subprocess_cwd = self.env.get("subprocess_cwd", self.env.get("RECIPE_CACHE_DIR"))
+        self.subprocess_fail_on_error = (
+            str(self.env.get("subprocess_fail_on_error")).lower() == "true"
+        )
+        self.subprocess_cwd = self.env.get(
+            "subprocess_cwd", self.env.get("RECIPE_CACHE_DIR")
+        )
 
         self.output(f"subprocess_args: {' '.join(self.subprocess_args)}")
-        result = subprocess.run(self.subprocess_args, shell=True, cwd=self.subprocess_cwd, capture_output=True, check=self.subprocess_fail_on_error, text=True, timeout=self.subprocess_timeout)
+        result = subprocess.run(
+            self.subprocess_args,
+            shell=True,
+            cwd=self.subprocess_cwd,
+            capture_output=True,
+            check=self.subprocess_fail_on_error,
+            text=True,
+            timeout=self.subprocess_timeout,
+        )
 
         self.env["subprocess_args"] = result.args
         self.env["subprocess_returncode"] = result.returncode
         self.output(f"subprocess_returncode: {self.env['subprocess_returncode']}")
-        self.env["subprocess_stdout"] = result.stdout.rstrip('\n')
+        self.env["subprocess_stdout"] = result.stdout.rstrip("\n")
         self.output(f"subprocess_stdout: {self.env['subprocess_stdout']}")
-        self.env["subprocess_stderr"] = result.stderr.rstrip('\n')
+        self.env["subprocess_stderr"] = result.stderr.rstrip("\n")
         self.output(f"subprocess_stderr: {self.env['subprocess_stderr']}")
+
 
 if __name__ == "__main__":
     PROCESSOR = RunShellCommand()

--- a/SharedProcessors/StringJoiner.py
+++ b/SharedProcessors/StringJoiner.py
@@ -53,7 +53,7 @@ class StringJoiner(Processor):
     input_variables = {
         "string_joiner_dict": {
             "required": False,
-            "description": "Dictionary of inputs, with the key as the resulting output variable name. See Processor Description for more details."
+            "description": "Dictionary of inputs, with the key as the resulting output variable name. See Processor Description for more details.",
         }
     }
     output_variables = {
@@ -64,18 +64,21 @@ class StringJoiner(Processor):
 
     description = __doc__
 
-
     def main(self):
         string_joiner_dict = self.env.get("string_joiner_dict")
 
         if not string_joiner_dict:
             return
         if type(string_joiner_dict) != dict:
-            raise ProcessorError(f"string_joiner_dict must be a dictionary - {type(string_joiner_dict)} provided.")
+            raise ProcessorError(
+                f"string_joiner_dict must be a dictionary - {type(string_joiner_dict)} provided."
+            )
 
         for result_output_var_name, string_joiner_input in string_joiner_dict.items():
             if type(string_joiner_input) != dict:
-                raise ProcessorError(f"string_joiner_dict values must all be dictionaries - {type(string_joiner_input)} provided for key {result_output_var_name}.")
+                raise ProcessorError(
+                    f"string_joiner_dict values must all be dictionaries - {type(string_joiner_input)} provided for key {result_output_var_name}."
+                )
 
             input_strings = string_joiner_input.get("input_strings")
             prefix = string_joiner_input.get("prefix")
@@ -93,7 +96,9 @@ class StringJoiner(Processor):
                     result_output += f"{str(value_prefix or '')}{input_string}{str(value_suffix or '')}"
 
                 if result_output:
-                    result_output = f"{str(prefix or '')}{result_output}{str(suffix or '')}"
+                    result_output = (
+                        f"{str(prefix or '')}{result_output}{str(suffix or '')}"
+                    )
 
             self.env[result_output_var_name] = result_output
             self.output(f"{result_output_var_name}: {self.env[result_output_var_name]}")

--- a/Shutter Encoder/ShutterEncoder.jamf-upload.recipe.yaml
+++ b/Shutter Encoder/ShutterEncoder.jamf-upload.recipe.yaml
@@ -24,13 +24,13 @@ Input:
   JAMF_PKG_INFO: |
     Shutter Encoder is one of the best video converter software, it handles images
     and audio too!
-    
+
     It has been designed by video editors in order to be as accessible and
     efficient as possible.
-    
+
     Shutter Encoder makes use of FFmpeg to handle its encoding, allowing support
     for almost every codec you've ever heard of, and many more you haven't.
-    
+
     Don't just take our word for it though, Avid themselves recommend Shutter
     Encoder as part of your Media Composer and ProTools ingesting workflow!
   JAMF_PKG_NOTES: 'Uploaded by AutoPkg'

--- a/Unity 3D/Unity3DComponent.munki.recipe.yaml
+++ b/Unity 3D/Unity3DComponent.munki.recipe.yaml
@@ -16,7 +16,7 @@ Description: |
     WebGL
     Windows-Mono
     Windows-Server
-  
+
   View the source at UNITY3D_SEARCH_URL to check for changes to available Components.
 
   Create separate overrides for each required component, giving each a unique Identifier.
@@ -61,7 +61,7 @@ Process:
             RECEIPT="%RECEIPT_PATH%/Unity3D_%UNITY3D_COMPONENT_NAME%_version.txt"
             INSTALLED_VERSION=$(cat "$RECEIPT")
             VERSION="%version%"
-        
+
             if [ ! -f "$RECEIPT" ] || [ "$INSTALLED_VERSION" != "$VERSION" ] && [[ "$INSTALLED_VERSION" < "$VERSION" ]]; then
                 exit 0
             else
@@ -72,13 +72,13 @@ Process:
             # Write version receipt to reference in installcheck_script as pkg receipt has no version
             RECEIPT="%RECEIPT_PATH%/Unity3D_%UNITY3D_COMPONENT_NAME%_version.txt"
             VERSION="%version%"
-        
+
             echo "$VERSION" > "$RECEIPT""
       postuninstall_script: |
         #!/bin/bash
             # Remove receipt
             RECEIPT="%RECEIPT_PATH%/Unity3D_%UNITY3D_COMPONENT_NAME%_version.txt"
-        
+
             if [ -f "$RECEIPT" ]; then
                 rm "$RECEIPT"
             fi"

--- a/Wireshark/WiresharkChmodBPF.pkg.recipe.yaml
+++ b/Wireshark/WiresharkChmodBPF.pkg.recipe.yaml
@@ -19,7 +19,7 @@ Process:
     expected_authority_names:
       - "Developer ID Installer: Wireshark Foundation (7Z6EMTD2C6)"
       - "Developer ID Certification Authority"
-      - "Apple Root CA"    
+      - "Apple Root CA"
 
 - Processor: FlatPkgUnpacker
   Arguments:

--- a/Yamaha/YamahaRRemote.pkg.recipe.yaml
+++ b/Yamaha/YamahaRRemote.pkg.recipe.yaml
@@ -20,7 +20,7 @@ Process:
   - Processor: FileFinder
     Arguments:
       pattern: '%RECIPE_CACHE_DIR%/unzip/*/*.pkg'
-      
+
 
   - Processor: CodeSignatureVerifier
     Arguments:

--- a/Youlean/YouleanLoudnessMeter2.download.recipe.yaml
+++ b/Youlean/YouleanLoudnessMeter2.download.recipe.yaml
@@ -7,7 +7,7 @@ MinimumVersion: 2.3.0
 Input:
   NAME: YouleanLoudnessMeter2
   SEARCH_RE: <a [^>]*href="([^"]*)"[^>]*>Download for macOS</a>
-  SEARCH_URL: https://youlean.co/download-youlean-loudness-meter  
+  SEARCH_URL: https://youlean.co/download-youlean-loudness-meter
 
 Process:
   - Processor: URLTextSearcher

--- a/macOSLAPS/macOSLAPS.jamf-upload.recipe.yaml
+++ b/macOSLAPS/macOSLAPS.jamf-upload.recipe.yaml
@@ -29,7 +29,7 @@ Process:
     Arguments:
       flat_pkg_path: '%pathname%'
       destination_path: '%RECIPE_CACHE_DIR%/unpack'
-  
+
   - Processor: com.github.nmcspadden.shared/PackageInfoVersioner
     Arguments:
       package_info_path: '%RECIPE_CACHE_DIR%/unpack/macOSLAPS.pkg/PackageInfo'


### PR DESCRIPTION
This PR updates the pre-commit hooks, which were previously failing to run. It also makes minor changes auto-applied by the pre-commit hooks. It does not address the remaining errors listed here:

```
% pre-commit run --all-files
[INFO] Initializing environment for https://github.com/homebysix/pre-commit-macadmin.
[INFO] Installing environment for https://github.com/homebysix/pre-commit-macadmin.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Check AutoPkg Recipes....................................................Failed
- hook id: check-autopkg-recipes
- exit code: 1

Digital Audio Denmark/DigitalAudioDenmark.cookie.recipe.yaml: Processor URLDownloader is not conventional for this recipe type.
Digital Audio Denmark/DigitalAudioDenmark.cookie.recipe.yaml: Processor EndOfCheckPhase is not conventional for this recipe type.
Webex/WebexAudioDriver.pkg.recipe.yaml: Recipe type pkg should contain one of these processors: ['AppPkgCreator', 'PkgCreator', 'PkgCopier'].
Generic/GenericDockItem.munki.recipe.yaml: Processor PkgCreator is not conventional for this recipe type.
iZotope/iZotope.pkg.recipe.yaml: Processor EndOfCheckPhase is not conventional for this recipe type.
Generic/GenericPayloadFreeDist.pkg.recipe.yaml: Recipe type pkg should contain one of these processors: ['AppPkgCreator', 'PkgCreator', 'PkgCopier'].
Jamf/JamfSelfService+.pkg.recipe.yaml: Processor EndOfCheckPhase is not conventional for this recipe type.
Jamf/JamfComposer.pkg.recipe.yaml: Processor EndOfCheckPhase is not conventional for this recipe type.
Celemony/CelemonyMelodyne.pkg.recipe.yaml: Processor EndOfCheckPhase is not conventional for this recipe type.

Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
black....................................................................Passed
check for added large files..............................................Passed
check python ast.........................................................Passed
check for case conflicts.................................................Passed
check docstring is first.................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...............................................................Passed
detect private key.......................................................Passed
fix utf-8 byte order marker..............................................Passed
mixed line ending........................................................Passed
don't commit to branch...................................................Passed
trim trailing whitespace.................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

AzulZuluJava/AzulZuluJavaInfoProvider.py:21:1: F401 'urllib.request' imported but unused
MicrosoftOneDrive/MicrosoftOneDriveVersioner.py:17:1: F401 'autopkglib.ProcessorError' imported but unused
MicrosoftOneDrive/MicrosoftOneDriveVersioner.py:65:9: F841 local variable 'replacement_string' is assigned to but never used
SharedProcessors/CodeSigner.py:18:1: F401 'plistlib' imported but unused
SharedProcessors/CodeSigner.py:21:1: F401 'shutil' imported but unused
SharedProcessors/FileTemplateFromLists.py:95:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
SharedProcessors/FileTemplateFromLists.py:104:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
SharedProcessors/FileTemplateFromLists.py:119:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
SharedProcessors/FlatToDistPkg.py:18:1: F401 'plistlib' imported but unused
SharedProcessors/FlatToDistPkg.py:22:1: F401 'autopkglib.ProcessorError' imported but unused
SharedProcessors/GitRepoClone.py:61:79: E712 comparison to True should be 'if cond is True:' or 'if cond:'
SharedProcessors/GitRepoClone.py:62:75: E712 comparison to True should be 'if cond is True:' or 'if cond:'
SharedProcessors/GitRepoClone.py:66:34: F541 f-string is missing placeholders
SharedProcessors/OSACompiler.py:18:1: F401 'plistlib' imported but unused
SharedProcessors/RunShellCommand.py:17:1: F401 'autopkglib.ProcessorError' imported but unused
SharedProcessors/StringJoiner.py:72:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
SharedProcessors/StringJoiner.py:78:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
SharedProcessors/StringJoiner.py:92:20: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```