### PR TITLE
Change PaperCut parent recipes to dataJAR download

### DIFF
--- a/PaperCut/PaperCutMF.download.recipe.yaml
+++ b/PaperCut/PaperCutMF.download.recipe.yaml
@@ -9,6 +9,10 @@ Input:
   BASE_URL: https://www.papercut.com/api/product/mf/latest/mac/
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: Consider switching to the PaperCutPrintDeployClient recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.
+
   - Processor: URLDownloader
     Arguments:
       url: '%BASE_URL%'

--- a/PaperCut/PaperCutMFStandardInstall.pkg.recipe.yaml
+++ b/PaperCut/PaperCutMFStandardInstall.pkg.recipe.yaml
@@ -4,7 +4,7 @@ Description: |
   the version, then copies the pkg.
 
 Identifier: com.github.davidbpirie.pkg.PaperCutMFStandardInstall
-ParentRecipe: com.github.davidbpirie.download.PaperCutMF
+ParentRecipe: com.github.dataJAR-recipes.download.PaperCut Print Deploy Client
 MinimumVersion: 2.3.0
 
 Input:

--- a/PaperCut/PaperCutPrintDeployClient.pkg.recipe.yaml
+++ b/PaperCut/PaperCutPrintDeployClient.pkg.recipe.yaml
@@ -5,7 +5,7 @@ Description: |
   PC Print Deploy Client pkg, then extracts the version.
 
 Identifier: com.github.davidbpirie.pkg.PaperCutPrintDeployClient
-ParentRecipe: com.github.davidbpirie.download.PaperCutMF
+ParentRecipe: com.github.dataJAR-recipes.download.PaperCut Print Deploy Client
 MinimumVersion: 2.3.0
 
 Input:


### PR DESCRIPTION
The PaperCut download recipe in this repo is redundant with the earlier-created equivalent in the dataJAR-recipes repo, which also include code signature verification. This PR adjusts the pkg recipes' parent to point to that one, and deprecates the download recipe in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

```
% autopkg run -vvq 'davidbpirie-recipes/PaperCut/'*.pkg.recipe.yaml                      
Processing davidbpirie-recipes/PaperCut/PaperCutMFStandardInstall.pkg.recipe.yaml...
WARNING: davidbpirie-recipes/PaperCut/PaperCutMFStandardInstall.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'PaperCutMFStandardInstall.dmg',
           'url': 'https://www.papercut.com/api/product/mf/latest/mac/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 13 Oct 2025 06:22:49 GMT
URLDownloader: Storing new ETag header: "77c7fd1020038daf3035a3a69ef3eb8f"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg
{'Output': {'download_changed': True,
            'etag': '"77c7fd1020038daf3035a3a69ef3eb8f"',
            'last_modified': 'Mon, 13 Oct 2025 06:22:49 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpacked',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg/PaperCut '
                            'MF Standard Install.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: No value supplied for skip_payload, setting default value of: False
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.u8EzWH/PaperCut MF Standard Install.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpacked
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpacked/appserver.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpacked/appserver.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut '
                      'MF/providers/print-deploy/mac/*/pc-print-deploy-client.dmg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg' from globbed '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut MF/providers/print-deploy/mac/*/pc-print-deploy-client.dmg'
FileFinder: Basename match: 'pc-print-deploy-client.dmg'
{'Output': {'found_basename': 'pc-print-deploy-client.dmg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut '
                              'MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg'}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall.pkg',
           'overwrite': True,
           'source_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut '
                          'MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg/PaperCut '
                          'Print Deploy Client.pkg'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg, dmg: .dmg/, dmg_source_path: PaperCut Print Deploy Client.pkg
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg
Copier: Copied /private/tmp/dmg.SfNEDX/PaperCut Print Deploy Client.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall.pkg
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: PaperCut '
                                        'Software International Pty Ltd '
                                        '(B5N3YV5P2H)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PaperCutMFStandardInstall.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-08-11 07:43:07 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PaperCut Software International Pty Ltd (B5N3YV5P2H)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            D2 FD D0 69 2B 0D 22 53 30 B0 F8 61 47 2D 88 76 16 D2 BF AD 71 FC 
CodeSignatureVerifier:            62 03 14 BC F2 79 0C 2C 2E AB
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
CodeSignatureVerifier
{'Input': {'deep_verification': True,
           'expected_authority_names': ['Developer ID Installer: PaperCut '
                                        'Software International Pty Ltd '
                                        '(B5N3YV5P2H)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg/PaperCut '
                         'MF Standard Install.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PaperCut MF Standard Install.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-10-13 00:23:17 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PaperCut Software International Pty Ltd (B5N3YV5P2H)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            D2 FD D0 69 2B 0D 22 53 30 B0 F8 61 47 2D 88 76 16 D2 BF AD 71 FC 
CodeSignatureVerifier:            62 03 14 BC F2 79 0C 2C 2E AB
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg/PaperCut '
                            'MF Standard Install.pkg',
           'purge_destination': True,
           'skip_payload': False}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.f8CU8D/PaperCut MF Standard Install.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack
{'Output': {}}
FileFinder
{'Input': {'find_method': 'glob',
           'pattern': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack/*.pkg'}}
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack/appserver.pkg' from globbed '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack/*.pkg'
FileFinder: Basename match: 'appserver.pkg'
{'Output': {'found_basename': 'appserver.pkg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack/appserver.pkg'}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack/appserver.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack/appserver.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'version-major=(.*)',
           'result_output_var_name': 'version_major',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut%20MF/release/version.txt'}}
URLTextSearcher: Found matching text (version_major): 25
{'Output': {'version_major': '25'}}
URLTextSearcher
{'Input': {'re_pattern': 'version-minor=(.*)',
           'result_output_var_name': 'version_minor',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut%20MF/release/version.txt'}}
URLTextSearcher: Found matching text (version_minor): 0
{'Output': {'version_minor': '0'}}
URLTextSearcher
{'Input': {'re_pattern': 'version-patch=(.*)',
           'result_output_var_name': 'version_patch',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut%20MF/release/version.txt'}}
URLTextSearcher: Found matching text (version_patch): 4
{'Output': {'version_patch': '4'}}
URLTextSearcher
{'Input': {'re_pattern': 'version-suffix=(.*)',
           'result_output_var_name': 'version_suffix',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload/PaperCut%20MF/release/version.txt'}}
URLTextSearcher: Found matching text (version_suffix): 
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall-25.0.4.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg/PaperCut '
                         'MF Standard Install.pkg'}}
PkgCopier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg
PkgCopier: Copied /private/tmp/dmg.9U9a2k/PaperCut MF Standard Install.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall-25.0.4.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall-25.0.4.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall-25.0.4.pkg'}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack',
                         '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/unpack
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/payload
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/receipts/PaperCutMFStandardInstall.pkg.recipe-receipt-20251026-222605.plist
Processing davidbpirie-recipes/PaperCut/PaperCutPrintDeployClient.pkg.recipe.yaml...
WARNING: davidbpirie-recipes/PaperCut/PaperCutPrintDeployClient.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'PaperCutPrintDeployClient.dmg',
           'url': 'https://www.papercut.com/api/product/mf/latest/mac/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 13 Oct 2025 06:22:49 GMT
URLDownloader: Storing new ETag header: "77c7fd1020038daf3035a3a69ef3eb8f"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg
{'Output': {'download_changed': True,
            'etag': '"77c7fd1020038daf3035a3a69ef3eb8f"',
            'last_modified': 'Mon, 13 Oct 2025 06:22:49 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpacked',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg/PaperCut '
                            'MF Standard Install.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: No value supplied for skip_payload, setting default value of: False
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.4aeY0l/PaperCut MF Standard Install.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpacked
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpacked/appserver.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpacked/appserver.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload
{'Output': {}}
FileFinder
{'Input': {'pattern': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut '
                      'MF/providers/print-deploy/mac/*/pc-print-deploy-client.dmg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg' from globbed '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/*/pc-print-deploy-client.dmg'
FileFinder: Basename match: 'pc-print-deploy-client.dmg'
{'Output': {'found_basename': 'pc-print-deploy-client.dmg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut '
                              'MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg'}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg',
           'overwrite': True,
           'source_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut '
                          'MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg/PaperCut '
                          'Print Deploy Client.pkg'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg, dmg: .dmg/, dmg_source_path: PaperCut Print Deploy Client.pkg
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg
Copier: Copied /private/tmp/dmg.xkV0Da/PaperCut Print Deploy Client.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: PaperCut '
                                        'Software International Pty Ltd '
                                        '(B5N3YV5P2H)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PaperCutPrintDeployClient.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-08-11 07:43:07 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PaperCut Software International Pty Ltd (B5N3YV5P2H)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            D2 FD D0 69 2B 0D 22 53 30 B0 F8 61 47 2D 88 76 16 D2 BF AD 71 FC 
CodeSignatureVerifier:            62 03 14 BC F2 79 0C 2C 2E AB
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
CodeSignatureVerifier
{'Input': {'deep_verification': True,
           'expected_authority_names': ['Developer ID Installer: PaperCut '
                                        'Software International Pty Ltd '
                                        '(B5N3YV5P2H)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg/PaperCut '
                         'MF Standard Install.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PaperCut MF Standard Install.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-10-13 00:23:17 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PaperCut Software International Pty Ltd (B5N3YV5P2H)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            D2 FD D0 69 2B 0D 22 53 30 B0 F8 61 47 2D 88 76 16 D2 BF AD 71 FC 
CodeSignatureVerifier:            62 03 14 BC F2 79 0C 2C 2E AB
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg/PaperCut '
                            'MF Standard Install.pkg',
           'purge_destination': True,
           'skip_payload': False}}
FlatPkgUnpacker: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.PaWQcD/PaperCut MF Standard Install.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack
{'Output': {}}
FileFinder
{'Input': {'find_method': 'glob',
           'pattern': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack/*.pkg'}}
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack/appserver.pkg' from globbed '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack/*.pkg'
FileFinder: Basename match: 'appserver.pkg'
{'Output': {'found_basename': 'appserver.pkg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack/appserver.pkg'}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack/appserver.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack/appserver.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload
{'Output': {}}
FileFinder
{'Input': {'find_method': 'glob',
           'pattern': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut '
                      'MF/providers/print-deploy/mac/v*/pc-print-deploy-client.dmg'}}
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg' from globbed '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/v*/pc-print-deploy-client.dmg'
FileFinder: Basename match: 'pc-print-deploy-client.dmg'
{'Output': {'found_basename': 'pc-print-deploy-client.dmg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut '
                              'MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg'}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut '
                         'MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg/*.pkg'}}
PkgCopier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload/PaperCut MF/providers/print-deploy/mac/v2025-08-14-0923_1.9.2932/pc-print-deploy-client.dmg
PkgCopier: Using path '/private/tmp/dmg.su2xkS/PaperCut Print Deploy Client.pkg' matched from globbed '/private/tmp/dmg.su2xkS/*.pkg'.
PkgCopier: Copied /private/tmp/dmg.su2xkS/PaperCut Print Deploy Client.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg'}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg',
           'purge_destination': True,
           'skip_payload': False}}
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack
{'Output': {}}
FileFinder
{'Input': {'find_method': 'glob',
           'pattern': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack/*.pkg'}}
FileFinder: Found file match: '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack/print-deploy-client.pkg' from globbed '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack/*.pkg'
FileFinder: Basename match: 'print-deploy-client.pkg'
{'Output': {'found_basename': 'print-deploy-client.pkg',
            'found_filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack/print-deploy-client.pkg'}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_payload',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack/print-deploy-client.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack/print-deploy-client.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_payload
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': '.*',
           'result_output_var_name': 'version',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_payload/PaperCut%20Print%20Deploy%20Client/.version'}}
URLTextSearcher: Found matching text (version): 2025-08-11-1742
{'Output': {'version': '2025-08-11-1742'}}
PathDeleter
{'Input': {'path_list': ['~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack',
                         '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload',
                         '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack',
                         '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_payload']}}
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/unpack
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/payload
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_unpack
PathDeleter: Deleted ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/client_payload
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/receipts/PaperCutPrintDeployClient.pkg.recipe-receipt-20251026-222634.plist

The following new items were downloaded:
    Download Path                                                                                                                     
    -------------                                                                                                                     
    ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/downloads/PaperCutMFStandardInstall.dmg  
    ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/downloads/PaperCutPrintDeployClient.dmg  

The following packages were copied:
    Pkg Path                                                                                                                       
    --------                                                                                                                       
    ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutMFStandardInstall/PaperCutMFStandardInstall-25.0.4.pkg  
    ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.PaperCutPrintDeployClient/PaperCutPrintDeployClient.pkg
```