### PR TITLE
Change GoogleWebDesigner.pkg parent to peshay download

### DIFF
--- a/GoogleWebDesigner/GoogleWebDesigner.download.recipe.yaml
+++ b/GoogleWebDesigner/GoogleWebDesigner.download.recipe.yaml
@@ -9,6 +9,10 @@ Input:
   URL: https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg
 
 Process:
+- Processor: DeprecationWarning
+  Arguments:
+    warning_message: Consider switching to the GoogleWebDesigner recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.
+
 - Processor: URLDownloader
   Arguments:
     filename: '%NAME%.dmg'

--- a/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe.yaml
+++ b/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe.yaml
@@ -2,7 +2,7 @@ Description: |
   Downloads the latest version of Google Web Designer, extracts the
   version, verifies the signature, then generates a pkg.
 Identifier: com.github.davidbpirie.pkg.GoogleWebDesigner
-ParentRecipe: com.github.davidbpirie.download.GoogleWebDesigner
+ParentRecipe: com.github.peshay.download.GoogleWebDesigner
 MinimumVersion: 2.3.0
 
 Input:


### PR DESCRIPTION
The GoogleWebDesigner download recipe in this repo is similar in function to the earlier-created one in peshay-recipes. This PR adjusts the pkg recipe to use peshay's download as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

Modified pkg recipe verbose output:

```
% autopkg run -vvq 'davidbpirie-recipes/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe.yaml'
Processing davidbpirie-recipes/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe.yaml...
WARNING: davidbpirie-recipes/GoogleWebDesigner/GoogleWebDesigner.pkg.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://dl.google.com/webdesigner/mac/shell/googlewebdesigner_mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 22 Jul 2025 16:38:02 GMT
URLDownloader: Storing new ETag header: "47fce8f"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
{'Output': {'download_changed': True,
            'etag': '"47fce8f"',
            'last_modified': 'Tue, 22 Jul 2025 16:38:02 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
AppDmgVersioner: BundleID: com.google.WebDesigner
AppDmgVersioner: Version: 14.2.4.0
{'Output': {'app_name': 'Google Web Designer.app',
            'bundleid': 'com.google.WebDesigner',
            'version': '14.2.4.0'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg/*.app',
           'requirement': 'identifier "com.google.WebDesigner" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'EQHXZ8M8AV'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.XceBTo/Google Web Designer.app' matched from globbed '/private/tmp/dmg.XceBTo/*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.XceBTo/Google Web Designer.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.XceBTo/Google Web Designer.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.XceBTo/Google Web Designer.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner/Applications/Google '
                               'Web Designer.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg/Google '
                          'Web Designer.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg, dmg: .dmg/, dmg_source_path: Google Web Designer.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg
Copier: Copied /private/tmp/dmg.4lres5/Google Web Designer.app to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner/Applications/Google Web Designer.app
{'Output': {}}
com.github.jessepeterson.munki.UniversalTypeClient5/ModeChanger
{'Input': {'filename': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner/Applications/Google '
                       'Web Designer.app',
           'mode': 'a+rx'}}
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.google.WebDesigner',
                           'options': 'purge_ds_store',
                           'pkgname': 'GoogleWebDesigner-14.2.4.0',
                           'pkgroot': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner',
                           'version': '14.2.4.0'}}}
PkgCreator: No value supplied for force_pkg_build, setting default value of: False
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.google.WebDesigner',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner-14.2.4.0.pkg',
                                                    'version': '14.2.4.0'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner-14.2.4.0.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/receipts/GoogleWebDesigner.pkg.recipe-receipt-20251109-123428.plist

The following new items were downloaded:
    Download Path                                                                                                         
    -------------                                                                                                         
    ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/downloads/googlewebdesigner_mac.dmg  

The following packages were built:
    Identifier              Version   Pkg Path                                                                                                         
    ----------              -------   --------                                                                                                         
    com.google.WebDesigner  14.2.4.0  ~/Library/AutoPkg/Cache/com.github.davidbpirie.pkg.GoogleWebDesigner/GoogleWebDesigner-14.2.4.0.pkg
```