### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Alice/Alice2.download.recipe.yaml
+++ b/Alice/Alice2.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: 2.3.0
 
 Input:
   NAME: Alice2
-  BASE_URL: http://www.alice.org/get-alice/alice-2/
+  BASE_URL: https://www.alice.org/get-alice/alice-2/
 
 Process:
 - Processor: URLTextSearcher

--- a/ComicLife/ComicLife3.download.recipe.yaml
+++ b/ComicLife/ComicLife3.download.recipe.yaml
@@ -4,7 +4,7 @@ MinimumVersion: 2.3.0
 
 Input:
   NAME: ComicLife3
-  DOWNLOAD_URL: http://downloads.plasq.com/comiclife3.zip
+  DOWNLOAD_URL: https://downloads.plasq.com/comiclife3.zip
 
 Process:
 - Processor: URLDownloader


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._